### PR TITLE
Stabilizing atoms

### DIFF
--- a/net-libs/rtrlib/rtrlib-0.5.0.ebuild
+++ b/net-libs/rtrlib/rtrlib-0.5.0.ebuild
@@ -5,15 +5,8 @@ EAPI=6
 
 inherit eutils flag-o-matic multilib readme.gentoo-r1 vcs-snapshot cmake-utils
 
-if [[ ${PV} != 9999 ]]; then
-	SRC_URI="https://github.com/rtrlib/rtrlib/archive/v${PV}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
-else
-	inherit git-r3
-	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/rtrlib/rtrlib.git"
-	KEYWORDS=""
-fi
+SRC_URI="https://github.com/rtrlib/rtrlib/archive/v${PV}.tar.gz"
+KEYWORDS="amd64 x86"
 
 DESCRIPTION="An open-source C implementation of the RPKI/Router Protocol client"
 HOMEPAGE="http://rtrlib.realmv6.org/"

--- a/net-misc/frr/frr-3.0.1.ebuild
+++ b/net-misc/frr/frr-3.0.1.ebuild
@@ -6,7 +6,8 @@ EAPI=6
 inherit autotools eutils flag-o-matic multilib pam readme.gentoo-r1 systemd tmpfiles user vcs-snapshot
 
 SRC_URI="https://github.com/FRRouting/frr/archive/FRR-3.0.1.tar.gz"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
+
 DESCRIPTION="Free Range Routing Protocol Suite, fork of Quagga"
 HOMEPAGE="https://frrouting.org/"
 

--- a/net-misc/frr/frr-3.0.2.ebuild
+++ b/net-misc/frr/frr-3.0.2.ebuild
@@ -5,15 +5,8 @@ EAPI=6
 
 inherit autotools eutils flag-o-matic multilib pam readme.gentoo-r1 systemd tmpfiles user vcs-snapshot
 
-if [[ ${PV} != 9999 ]]; then
-	SRC_URI="https://github.com/FRRouting/frr/archive/${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
-else
-	inherit git-r3
-	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/FRRouting/frr.git"
-	KEYWORDS=""
-fi
+SRC_URI="https://github.com/FRRouting/frr/archive/${P}.tar.gz"
+KEYWORDS="amd64 x86"
 
 DESCRIPTION="Free Range Routing Protocol Suite, fork of Quagga"
 HOMEPAGE="https://frrouting.org/"

--- a/net-misc/frr/frr-3.0.ebuild
+++ b/net-misc/frr/frr-3.0.ebuild
@@ -5,15 +5,8 @@ EAPI=6
 
 inherit autotools eutils flag-o-matic multilib pam readme.gentoo-r1 systemd tmpfiles user vcs-snapshot
 
-if [[ ${PV} != 9999 ]]; then
-	SRC_URI="https://github.com/FRRouting/frr/archive/${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
-else
-	inherit git-r3
-	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/FRRouting/frr.git"
-	KEYWORDS=""
-fi
+SRC_URI="https://github.com/FRRouting/frr/archive/${P}.tar.gz"
+KEYWORDS="amd64 x86"
 
 DESCRIPTION="Free Range Routing Protocol Suite, fork of Quagga"
 HOMEPAGE="https://frrouting.org/"


### PR DESCRIPTION
Marked stable amd64 and x86 builds for atoms:
=net-libs/rtrlib/rtrlib-0.5.0
=net-misc/frr/frr-3.0.1
=net-misc/frr/frr-3.0.2
=net-misc/frr/frr-3.0

Package-Manager: Portage-2.3.16, Repoman-2.3.6